### PR TITLE
fix error when API call returns HTTP 4xx

### DIFF
--- a/tado-openapispec-v2.yaml
+++ b/tado-openapispec-v2.yaml
@@ -2861,9 +2861,6 @@ components:
 
     Error:
       type: object
-      description: >
-        The zoneType is only available for certain 422 errors, 
-        to indicate that a certain zone specific operation is not allowed because of the ZoneType of the zone.
       properties:
         code:
           type: string
@@ -2872,22 +2869,34 @@ components:
           type: string
           description: detailed description of the error in natural language (english)
 
+    Error422:
+      description: >
+        The zoneType is only available for certain 422 errors, 
+        to indicate that a certain zone specific operation is not allowed because of the ZoneType of the zone.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - properties:
+            zoneType:
+              $ref: '#/components/schemas/ZoneType'
+
     ErrorResponse:
-      type: array
+      type: object
       description: error object returned for non-200 responses
-      items:
-        $ref: '#/components/schemas/Error'
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error'
 
     ErrorResponse422:
-      type: array
+      type: object
       description: error object returned for 422 responses
-      items:
-        type: object
-        allOf:
-          - $ref: '#/components/schemas/Error'
-          - properties:
-              zoneType:
-                $ref: '#/components/schemas/ZoneType'
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error422'
 
     # FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     FanLevel:


### PR DESCRIPTION
The spec currently defines an ErrorResponse (and its related ErrorResponse422) as an array of Error objects.  This is actually incorrect.  Tado returns errors as follows:

```
{
    "errors": [
        {"code":"unauthorized","title":"Full authentication is required to access this resource"}
    ]
}
```

So, it's an object with one field, "errors", holding the array of errors.

This PR fixes this.